### PR TITLE
Improve list-all

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -50,7 +50,7 @@ get_arch () {
 get_download_url () {
   local -r version="$1"
   local -r arch="$(get_arch)"
-  echo "https://github.com/$repository/releases/download/$version/${toolname}-${arch}-${version/v}.zip"
+  echo "https://github.com/${repository}/releases/download/v${version}/${toolname}-${arch}-${version}.zip"
 }
 
 install "${ASDF_INSTALL_TYPE}" "${ASDF_INSTALL_VERSION}" "${ASDF_INSTALL_PATH}"

--- a/bin/list-all
+++ b/bin/list-all
@@ -5,12 +5,16 @@ set \
   -o nounset \
   -o pipefail
 
-readonly repository="bitwarden/cli"
+readonly repository='bitwarden/cli'
 
-cmd="curl -s"
+readonly jq_script='.[] | select(.prerelease == false) | .tag_name | sub("v"; "")'
+
+cmd='curl --fail --silent'
 if [ -n "${OAUTH_TOKEN:-}" ]; then
-  cmd="$cmd -H 'Authorization: token $OAUTH_TOKEN'"
+  cmd="${cmd} -H 'Authorization: token ${OAUTH_TOKEN}'"
 fi
-cmd="$cmd https://api.github.com/repos/$repository/releases"
-versions=$(eval $cmd | grep tag_name | sed 's/"tag_name": //g;s/"//g;s/,//g' | (tac 2>/dev/null || tail -r) | xargs)
-echo $versions
+
+eval "${cmd} 'https://api.github.com/repos/${repository}/releases'"|
+  jq -r "${jq_script}" |
+  tac |
+  xargs echo


### PR DESCRIPTION
* Use jq to parse releases json.
* Skip pre-release versions.
* Drop the `v` in the tag to match asdf standards.
* Fix some curlybrace inconsistencies.
* Fix some quoting inconsistencies.

Signed-off-by: Ben Kochie <superq@gmail.com>