### PR TITLE
Work with Bitwarden's new clients repo

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,20 @@
+---
+on:
+  workflow_dispatch:
+  push:
+
+jobs:
+  test_plugin:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        bash_compat: ["32", ""]
+    env:
+      BASH_COMPAT: ${{ matrix.bash_compat }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Test plugin
+        uses: asdf-vm/actions/plugin-test@v1
+        with:
+          command: "bw --version"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: c
-script: asdf plugin-test bw $TRAVIS_BUILD_DIR 'bw --version'
-before_script:
-  - git clone https://github.com/asdf-vm/asdf.git asdf
-  - . asdf/asdf.sh
-os:
-  - linux
-  - osx

--- a/bin/constants.bash
+++ b/bin/constants.bash
@@ -1,0 +1,9 @@
+# required environment variables
+: "${ASDF_INSTALL_VERSION?}"
+: "${ASDF_INSTALL_PATH?}"
+: "${ASDF_DOWNLOAD_PATH?}"
+
+toolname="bw"
+old_repository="bitwarden/cli"
+repository="bitwarden/clients"
+prefix="cli-"

--- a/bin/download
+++ b/bin/download
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(dirname -- "$0")/constants.bash"
+source "$(dirname -- "$0")/utils.bash"
+
+download_path="${ASDF_DOWNLOAD_PATH:-$(mktemp -d -t "asdf_${toolname}_XXXXXX")}"
+[[ -z "$ASDF_DOWNLOAD_PATH" ]] && trap 'rm -rf "${TMP_DOWNLOAD_DIR?}"' EXIT
+
+do_download () {
+  local -r install_type="$1"
+  local -r version="$2"
+
+  local -r download_url="$(get_download_url "${version}")"
+
+  if ! download "$download_url" "$ASDF_DOWNLOAD_PATH"; then
+    echo "Error: ${toolname} version ${version} not found" >&2
+    exit 1
+  fi
+}
+
+do_download "${ASDF_INSTALL_TYPE}" "${ASDF_INSTALL_VERSION}"

--- a/bin/install
+++ b/bin/install
@@ -1,20 +1,11 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-set \
-  -o nounset \
-  -o pipefail \
-  -o errexit
-
-# required environment variables
-: ${ASDF_INSTALL_TYPE?}
-: ${ASDF_INSTALL_VERSION?}
-: ${ASDF_INSTALL_PATH?}
-
-readonly repository="bitwarden/cli"
-readonly toolname="bw"
+source "$(dirname -- "$0")/constants.bash"
+source "$(dirname -- "$0")/utils.bash"
 
 # make a temporary download directory with a cleanup hook
-readonly TMP_DOWNLOAD_DIR="$(mktemp -d -t "asdf_${toolname}_XXXXXX")"
+TMP_DOWNLOAD_DIR="$(mktemp -d -t "asdf_${toolname}_XXXXXX")"
 trap 'rm -rf "${TMP_DOWNLOAD_DIR?}"' EXIT
 
 install () {
@@ -26,31 +17,21 @@ install () {
   local -r download_url="$(get_download_url "${version}")"
   local -r download_path="${TMP_DOWNLOAD_DIR}/$(basename "${download_url}")"
 
-  echo "Downloading ${toolname} version ${version} from ${download_url}"
-  if curl -fsL "${download_url}" -o "${download_path}"; then
+  
+  if download "$download_url" "$download_path"; then
     echo "Cleaning ${toolname} previous binaries"
-    rm -rf "${bin_install_path}/${toolname}"
+    rm -rf "${bin_install_path}/${toolname:?}"
 
     echo "Creating ${toolname} bin directory"
     mkdir -p "${bin_install_path}"
 
     echo "Extracting ${toolname} archive"
     unzip -qq "$download_path" -d "$bin_install_path"
-    chmod +x "$bin_install_path/bw"
+    chmod +x "$bin_install_path/$toolname"
   else
     echo "Error: ${toolname} version ${version} not found" >&2
     exit 1
   fi
-}
-
-get_arch () {
-  uname | tr '[:upper:]' '[:lower:]' | sed 's/darwin/macos/g'
-}
-
-get_download_url () {
-  local -r version="$1"
-  local -r arch="$(get_arch)"
-  echo "https://github.com/$repository/releases/download/$version/${toolname}-${arch}-${version/v}.zip"
 }
 
 install "${ASDF_INSTALL_TYPE}" "${ASDF_INSTALL_VERSION}" "${ASDF_INSTALL_PATH}"

--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -17,6 +17,5 @@ if [ -n "${GITHUB_TOKEN:-}" ]; then
   oauth_header=("-H" "Authorization: token $GITHUB_TOKEN")
 fi
 
-old_versions=$(get_versions "$old_repository")
-versions=$(get_versions "$repository")
-echo "$old_versions" "$versions" | xargs
+versions=("$(get_versions "$repository")")
+get_latest_version "${versions[@]}"

--- a/bin/utils.bash
+++ b/bin/utils.bash
@@ -1,0 +1,55 @@
+source "$(dirname -- "$0")/constants.bash"
+
+download () {
+  local -r download_url="$1"
+  local -r download_path="$2"
+
+  echo "Downloading ${toolname} version ${ASDF_INSTALL_VERSION} from ${download_url}"
+  curl -fsL "${download_url}" -o "${download_path}"
+  if [[ ! "$?" ]] ; then
+    echo "Error: ${toolname} version ${ASDF_INSTALL_VERSION} not found" >&2
+    exit 1
+  fi
+}
+
+get_download_url () {
+  local version="v$1"
+
+  local -r repository="$(get_repository "$version")"
+  [[ "$version" == "latest" ]] && \
+    versions=("$(get_versions "$repository")") && \
+    version="$(get_latest_version "${versions[@]}")"
+
+  [[ "$repository" == "bitwarden/clients" ]] && \
+    version="cli-$version"
+
+  local -r arch="$(get_arch)"
+  printf "https://github.com/%s/releases/download/%s/%s-%s-%s.zip\n" \
+    "$repository" "$version" "$toolname" "$arch" "${version/cli-v}"
+}
+
+get_repository () {
+  case "$1" in 
+    1.* )  echo "$old_repository" ;;
+    *   )  echo "$repository" ;;
+  esac
+}
+
+get_arch () {
+  uname | tr '[:upper:]' '[:lower:]' | sed 's/darwin/macos/g'
+}
+
+get_versions() {
+  local repo="$1"
+
+  curl -s "${oauth_header[@]}" "https://api.github.com/repos/$repo/releases" | \
+    grep "tag_name" | \
+    cut -f 4 -d \" | \
+    grep -E "^(cli-)?v" | \
+    grep -oE "[0-9\.]+" | \
+    tac
+}
+
+get_latest_version () {
+  tail -n1 <<< "$1"
+}


### PR DESCRIPTION
As of May 25, 2022, bitwaden uses https://github.com/bitwarden/clients for the cli.

This PR adds in support for that. 